### PR TITLE
Make pug dependency flexible/agnostic

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,11 @@ gulp-pug
 ========
 > Gulp plugin for compiling Pug templates.
 
+A _version agnostic_ Gulp plugin for compiling Pug templates.  In order to use, you must install a version of `pug` alongside `gulp-pug`...  This is so `gulp-pug` can rely on the version of `pug` that you want.
+
 ## Installation
 ```shell
-$ npm install --save-dev gulp-pug
+$ npm install --save-dev gulp-pug pug
 ```
 
 ## Usage

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gulp-pug",
-  "version": "0.4.2",
+  "version": "1.0.0",
   "description": "Gulp plugin for compiling Pug templates.",
   "main": "out/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -38,7 +38,10 @@
   },
   "dependencies": {
     "gulp-util": "^3.0.7",
-    "pug": "^0.1.0",
     "through2": "^2.0.1"
+  },
+  "peerDependencies": {
+    "pug": "*",
+    "gulp": "*"
   }
 }


### PR DESCRIPTION
This makes it so you have to install a version of `pug` alongside `gulp-pug`, so that way everyone can be happy with their own version, and continuous updates will not be needed.

Closes #2 