### PR TITLE
setting data to opts.data even if there is no file data so we can still pass in template variables from our gulp task

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -24,7 +24,7 @@ module.exports = function gulpPug(opts) {
 
     opts.data = opts.data || {};
 
-    var data;
+    var data = opts.data;
     if (file.data) {
       data = extend(opts.data, file.data);
     }


### PR DESCRIPTION
We have a gulp task that passes locals into gulp-pug along with the rest of the options object, some relatively recent code changes prevented this from working. 