### PR TITLE
Fix flexibility in options.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -24,9 +24,9 @@ module.exports = function gulpPug(opts) {
 
     opts.data = opts.data || {};
 
-    var data;
+    var data = opts.data;
     if (file.data) {
-      data = extend(opts.data, file.data);
+      data = extend(data, file.data);
     }
 
     // Replace contents

--- a/test/variable.js
+++ b/test/variable.js
@@ -17,11 +17,15 @@ test.cb('compiling', t => {
       foo: 'bar'
     };
   }))
-  .pipe(pug())
+  .pipe(pug({
+    data: {
+      bar: 'qux'
+    }
+  }))
   .pipe(gulp.dest('.'))
   .on('data', function(file) {
     t.deepEqual(file.contents.toString(),
-'<p>bar</p>');
+'<p>bar</p><div>qux</div>');
     t.is(extname(file.path), '.html');
     t.end();
   });

--- a/test/variable.pug
+++ b/test/variable.pug
@@ -1,1 +1,2 @@
 p= foo
+div= bar


### PR DESCRIPTION
This allows you to use `opts.data`, as well as `gulp-data` at the same time.  (Related #15)